### PR TITLE
update df plugin usage, add disk plugin

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,3 +22,6 @@ Environment variables
 * `GRAPHITE_PORT`
   - Graphite port
   - Optional, defaults to 2003
+* `GRAPHITE_PREFIX`
+  - Graphite prefix
+  - Optional, defaults to collectd.

--- a/README.md
+++ b/README.md
@@ -6,7 +6,8 @@ Basic collectd-based server monitoring. Sends stats to Graphite.
 Collectd metrics:
 
 * CPU used/free/idle/etc
-* Free disk (via the .dockerinit filesystem)
+* Free disk (via mounting hosts '/' into container, eg: -v /:/hostfs:ro)
+* Disk performance
 * Load average
 * Memory used/free/etc
 

--- a/collectd.conf.tpl
+++ b/collectd.conf.tpl
@@ -24,6 +24,7 @@ LoadPlugin write_graphite
  <Carbon>
    Host "{{ GRAPHITE_HOST }}"
    Port "{{ GRAPHITE_PORT | default("2003") }}"
+   Prefix "{{ GRAPHITE_PREFIX | default("collectd.") }}"
    EscapeCharacter "_"
    SeparateInstances true
    StoreRates true

--- a/collectd.conf.tpl
+++ b/collectd.conf.tpl
@@ -9,15 +9,41 @@ LoadPlugin cpu
 LoadPlugin df
 LoadPlugin load
 LoadPlugin memory
+LoadPlugin disk
 LoadPlugin write_graphite
 
 <Plugin df>
-  Device "hostfs"
-  MountPoint "/.dockerinit"
-  IgnoreSelected false
+  # expose host's mounts into container using -v /:/host:ro  (location inside container does not matter much)
+  # ignore rootfs; else, the root file-system would appear twice, causing
+  # one of the updates to fail and spam the log
+  FSType rootfs
+  # ignore the usual virtual / temporary file-systems
+  FSType sysfs
+  FSType proc
+  FSType devtmpfs
+  FSType devpts
+  FSType tmpfs
+  FSType fusectl
+  FSType cgroup
+  FSType overlay
+  FSType debugfs
+  FSType pstore
+  FSType securityfs
+  FSType hugetlbfs
+  FSType squashfs
+  FSType mqueue
+  MountPoint "/etc/resolv.conf"
+  MountPoint "/etc/hostname"
+  MountPoint "/etc/hosts"
+  IgnoreSelected true
   ReportByDevice false
   ReportReserved true
   ReportInodes true
+</Plugin>
+
+<Plugin "disk">
+  Disk "/^[hs]d[a-z]/"
+  IgnoreSelected false
 </Plugin>
 
 <Plugin "write_graphite">


### PR DESCRIPTION
I've changed the df plugin usage to not depend on /.dockerinit, which doesn't appear to work anymore with newer docker versions. It now requires the hosts '/' to be mounted (readonly) into the collectd container.
I also added the disk plugin.
This also includes one commit from nikut/docker-collectd-write-graphite which adds support for environment variable GRAPHITE_PREFIX.
Tested against KairosDB with Graphite protocol plugin enabled.