### PR TITLE
update collectd to 5.5.0, add uptime, swap, network

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,11 +1,7 @@
-FROM    ubuntu:precise
+FROM    ubuntu:xenial
 
 ENV     DEBIAN_FRONTEND noninteractive
 
-# only later versions of collectd have the graphite plugin
-RUN     echo "deb http://us.archive.ubuntu.com/ubuntu/ precise universe" >> /etc/apt/sources.list
-RUN     echo "deb http://ppa.launchpad.net/vbulax/collectd5/ubuntu precise main" >> /etc/apt/sources.list
-RUN     apt-key adv --recv-keys --keyserver keyserver.ubuntu.com 232E4010A519D8D831B81C56C1F5057D013B9839
 RUN     apt-get -y update
 RUN     apt-get -y install collectd curl python-pip
 

--- a/README.md
+++ b/README.md
@@ -10,6 +10,9 @@ Collectd metrics:
 * Disk performance
 * Load average
 * Memory used/free/etc
+* Uptime
+* Network interface
+* Swap
 
 Environment variables
 ---------------------
@@ -26,3 +29,7 @@ Environment variables
 * `GRAPHITE_PREFIX`
   - Graphite prefix
   - Optional, defaults to collectd.
+* `REPORT_BY_CPU`
+  - Report per-CPU metrics if true, global sum of CPU metrics if false (details: [collectd.conf man page](https://collectd.org/documentation/manpages/collectd.conf.5.shtml#plugin_cpu))
+  - Optional, defaults to false.
+

--- a/collectd.conf.tpl
+++ b/collectd.conf.tpl
@@ -15,6 +15,10 @@ LoadPlugin uptime
 LoadPlugin swap
 LoadPlugin write_graphite
 
+<Plugin cpu>
+  ReportByCpu {{ REPORT_BY_CPU | default("false") }}
+</Plugin>
+
 <Plugin df>
   # expose host's mounts into container using -v /:/host:ro  (location inside container does not matter much)
   # ignore rootfs; else, the root file-system would appear twice, causing

--- a/collectd.conf.tpl
+++ b/collectd.conf.tpl
@@ -10,6 +10,9 @@ LoadPlugin df
 LoadPlugin load
 LoadPlugin memory
 LoadPlugin disk
+LoadPlugin interface
+LoadPlugin uptime
+LoadPlugin swap
 LoadPlugin write_graphite
 
 <Plugin df>
@@ -45,6 +48,15 @@ LoadPlugin write_graphite
   Disk "/^[hs]d[a-z]/"
   IgnoreSelected false
 </Plugin>
+
+
+<Plugin interface>
+  Interface "lo"
+  Interface "/^veth.*/"
+  Interface "/^docker.*/"
+  IgnoreSelected true
+</Plugin>
+
 
 <Plugin "write_graphite">
  <Carbon>


### PR DESCRIPTION
- update collectd to version 5.5.0 by updating base image from precise to xenial
- cpu plugin ReportByCpu config added, controlled via env var REPORT_BY_CPU (defaults to false)
- network interface plugin added, configured to ignore loopback and docker related interfaces (lo, docker*, veth*)
tested against KairosDB backend.