### PR TITLE
Fix disk plugin RegEx to match all possible EC2 volume device patterns

### DIFF
--- a/collectd.conf.tpl
+++ b/collectd.conf.tpl
@@ -49,7 +49,7 @@ LoadPlugin write_graphite
 </Plugin>
 
 <Plugin "disk">
-  Disk "/^[hs]d[a-z]/"
+  Disk "/^(([hs]|xv)d[a-z][a-z]?[0-9]*|nvme[0-9]+n1|mapper\/.*|dm-[0-9]+)$/"
   IgnoreSelected false
 </Plugin>
 


### PR DESCRIPTION
Updates the disk plugin regex to match [newer EC2 volume device names][1].

[1]: https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/device_naming.html